### PR TITLE
docs: Add press section

### DIFF
--- a/src/docs/index.rst
+++ b/src/docs/index.rst
@@ -22,6 +22,7 @@ Explore Datavzrd's capabilities by checking out an `example report online <https
     usage
     examples
     publications
+    press
     interaction
     tutorial
     configuration

--- a/src/docs/press.rst
+++ b/src/docs/press.rst
@@ -1,0 +1,14 @@
+Datavzrd in the Press
+=====================
+
+This page highlights selected mentions of Datavzrd in news articles, institutional websites, and other media coverage.
+
++--------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **Source**                                 | **Link**                                                                                                                                                 |
++============================================+==========================================================================================================================================================+
+| Universität Duisburg-Essen                 | `Datavzrd makes complex data understandable <https://www.uni-due.de/2025-07-23-datavzrd-makes-complex-data-understandable>`__                            |
++--------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Science News Today                         | `This simple tool transforms raw data into living science <https://www.sciencenewstoday.org/this-simple-tool-transforms-raw-data-into-living-science>`__ |
++--------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+We welcome further mentions! If you have written about Datavzrd or seen it featured somewhere, feel free to let us know.


### PR DESCRIPTION
This pull request adds a new documentation page to highlight media mentions of Datavzrd. The page includes a table summarizing selected mentions with links to articles and institutional websites.

### Documentation updates:

* [`src/docs/press.rst`](diffhunk://#diff-98185d0426ace1c1b9fa9dfaa7b8316f5024bea94579acb3e26f2b43dbd90e21R1-R14): Added a new "Datavzrd in the Press" section, including a table with sources and links to media coverage, such as Universität Duisburg-Essen and Science News Today. The page also invites users to share additional mentions of Datavzrd.