### PR TITLE
docs: Clarify that link-to-url custom-content sets the button label, not the url

### DIFF
--- a/src/docs/configuration.rst
+++ b/src/docs/configuration.rst
@@ -527,19 +527,27 @@ link-to-url
      - Whether or not the rendered link will be opened in a new window or not
      - true
 
-It is also possible to use `custom-content` to change the content of the dropdown button.
+Each link is a named entry that holds a ``url``. Providing more than one named entry renders them as a dropdown menu.
 
 Example:
 
 .. code-block:: yaml
 
     link-to-url:
-        custom-content: function(value, row) { return `Find out more about ${value}`; }
         Wikipedia:
-                url: "https://de.wikipedia.org/wiki/{value}"
+            url: "https://de.wikipedia.org/wiki/{value}"
         Letterboxd:
-                url: "https://letterboxd.com/search/{value}"
-                new-window: false
+            url: "https://letterboxd.com/search/{value}"
+            new-window: false
+
+Optionally, ``custom-content`` customizes the text shown on the link or dropdown button through a JavaScript function of ``value`` and ``row`` that returns the label to display:
+
+.. code-block:: yaml
+
+    link-to-url:
+        Wikipedia:
+            url: "https://de.wikipedia.org/wiki/{value}"
+        custom-content: function(value, row) { return `Find out more about ${value}`; }
 
 plot
 ====


### PR DESCRIPTION
The `link-to-url` section led its example with `custom-content` and never showed the plain named-link form on its own, which makes it easy to read `custom-content` as the place to put a URL.

This clarifies that:

- each link is a named entry that holds a `url` (multiple entries render as a dropdown), and
- `custom-content` is an optional JavaScript function that only sets the text on the link/dropdown button — it is not a url and does not create a link by itself.

The example now shows the named-link form first, and `custom-content` separately as a label override.